### PR TITLE
Since v11 botpress has stopped storing logs in files and has moved th…

### DIFF
--- a/step-1/botfile.js
+++ b/step-1/botfile.js
@@ -40,12 +40,11 @@ module.exports = {
   contentDataDir: './src/content_data',
 
   /*
-    By default logs are enabled and available in `dataDir`
-   */
-  disableFileLogs: false,
-  log: {
-    file: 'bot.log',
-    maxSize: 1e6 // 1mb
+    By default logs are enabled and stored in the DB for 30 days
+  */
+  logs: {
+    enabled: true,
+    keepDays: 30
   },
 
   /*


### PR DESCRIPTION
…em to the database.

     Old configuration format:
        /*
          By default logs are enabled and available in dataDir
        */
        disableFileLogs: false,
        log: {
          file: 'bot.log',
          maxSize: 1e6 // 1mb
        }

      New format:
        /*
          By default logs are enabled and stored in the DB for 30 days
        */
        logs: {
          enabled: true,
          keepDays: 30
        }